### PR TITLE
Quaternion slerp() using incorrect precision

### DIFF
--- a/include/boost/qvm/quat_operations.hpp
+++ b/include/boost/qvm/quat_operations.hpp
@@ -719,7 +719,7 @@ boost
             TR sc=one;
             if( dp < one )
                 {
-                TR const theta = acosf(dp);
+                TR const theta = acos<TR>(dp);
                 TR const invsintheta = one/sin<TR>(theta);
                 TR const scale = sin<TR>(theta*(one-t)) * invsintheta;
                 TR const invscale = sin<TR>(theta*t) * invsintheta * sc;


### PR DESCRIPTION
In my use cases, the slerp operation returned a quaternion with nan-values because the angle between input quaternions was too low. I used double precision for the quaternions, but the acosf() function reduced the calculation accuracy, resulting in "theta==0.0".

Using acos<TR> instead of acosf is consistent with the other trigonometrical functions used in this method and solves the problem of precision loss in my use case.

(With even smaller angle differences, the calculation could still result in nan-quaternions when using double precision, but this is still an improvement, imho.)