### PR TITLE
Fix -Wunused-parameter in quat_operations.hpp

### DIFF
--- a/include/boost/qvm/quat_operations.hpp
+++ b/include/boost/qvm/quat_operations.hpp
@@ -234,7 +234,7 @@ quat_traits< qvm_detail::identity_quat_<T> >
     static
     BOOST_QVM_CONSTEXPR BOOST_QVM_INLINE_CRITICAL
     scalar_type
-    read_element( this_quaternion const & x )
+    read_element( this_quaternion const & )
         {
         BOOST_QVM_STATIC_ASSERT(I>=0);
         BOOST_QVM_STATIC_ASSERT(I<4);
@@ -244,7 +244,7 @@ quat_traits< qvm_detail::identity_quat_<T> >
     static
     BOOST_QVM_CONSTEXPR BOOST_QVM_INLINE_CRITICAL
     scalar_type
-    read_element_idx( int i, this_quaternion const & x )
+    read_element_idx( int i, this_quaternion const & )
         {
         BOOST_QVM_ASSERT(i>=0);
         BOOST_QVM_ASSERT(i<4);
@@ -901,7 +901,7 @@ quat_traits< qvm_detail::zero_q_<T> >
     static
     BOOST_QVM_CONSTEXPR BOOST_QVM_INLINE_CRITICAL
     scalar_type
-    read_element( this_quaternion const & x )
+    read_element( this_quaternion const & )
         {
         BOOST_QVM_STATIC_ASSERT(I>=0);
         BOOST_QVM_STATIC_ASSERT(I<4);
@@ -911,7 +911,7 @@ quat_traits< qvm_detail::zero_q_<T> >
     static
     BOOST_QVM_CONSTEXPR BOOST_QVM_INLINE_CRITICAL
     scalar_type
-    read_element_idx( int i, this_quaternion const & x )
+    read_element_idx( int i, this_quaternion const & )
         {
         BOOST_QVM_ASSERT(i>=0);
         BOOST_QVM_ASSERT(i<4);


### PR DESCRIPTION
```
/opt/homebrew/include/boost/qvm/quat_operations.hpp:237:43: warning: unused parameter 'x' [-Wunused-parameter]
    read_element( this_quaternion const & x )
                                          ^
/opt/homebrew/include/boost/qvm/quat_operations.hpp:247:54: warning: unused parameter 'x' [-Wunused-parameter]
    read_element_idx( int i, this_quaternion const & x )
                                                     ^
/opt/homebrew/include/boost/qvm/quat_operations.hpp:904:43: warning: unused parameter 'x' [-Wunused-parameter]
    read_element( this_quaternion const & x )
                                          ^
/opt/homebrew/include/boost/qvm/quat_operations.hpp:914:54: warning: unused parameter 'x' [-Wunused-parameter]
    read_element_idx( int i, this_quaternion const & x )
```