### PR TITLE
Fix unused parameter warning in Release builds

### DIFF
--- a/include/boost/qvm/map_vec_mat.hpp
+++ b/include/boost/qvm/map_vec_mat.hpp
@@ -78,7 +78,7 @@ qvm_detail
         scalar_type &
         write_element_idx( int row, int col, this_matrix & x )
             {
-            BOOST_QVM_ASSERT(col==0);
+            BOOST_QVM_ASSERT(col==0); (void)col;
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows);
             return vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x));
@@ -111,7 +111,7 @@ qvm_detail
         void
         write_element_idx( int row, int col, this_matrix & x, scalar_type s )
             {
-            BOOST_QVM_ASSERT(col==0);
+            BOOST_QVM_ASSERT(col==0); (void)col;
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows);
             vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x), s);
@@ -146,7 +146,7 @@ mat_traits< qvm_detail::col_mat_<OriginalVector> >:
     scalar_type
     read_element_idx( int row, int col, this_matrix const & x )
         {
-        BOOST_QVM_ASSERT(col==0);
+        BOOST_QVM_ASSERT(col==0); (void)col;
         BOOST_QVM_ASSERT(row>=0);
         BOOST_QVM_ASSERT(row<rows);
         return vec_traits<OriginalVector>::read_element_idx(row,reinterpret_cast<OriginalVector const &>(x));
@@ -254,7 +254,7 @@ qvm_detail
         scalar_type &
         write_element_idx( int row, int col, this_matrix & x )
             {
-            BOOST_QVM_ASSERT(row==0);
+            BOOST_QVM_ASSERT(row==0); (void)row;
             BOOST_QVM_ASSERT(col>=0);
             BOOST_QVM_ASSERT(col<cols);
             return vec_traits<OriginalVector>::write_element_idx(col,reinterpret_cast<OriginalVector &>(x));
@@ -287,7 +287,7 @@ qvm_detail
         void
         write_element_idx( int row, int col, this_matrix & x, scalar_type s )
             {
-            BOOST_QVM_ASSERT(row==0);
+            BOOST_QVM_ASSERT(row==0); (void)row;
             BOOST_QVM_ASSERT(col>=0);
             BOOST_QVM_ASSERT(col<cols);
             vec_traits<OriginalVector>::write_element_idx(col,reinterpret_cast<OriginalVector &>(x), s);
@@ -322,7 +322,7 @@ mat_traits< qvm_detail::row_mat_<OriginalVector> >:
     scalar_type
     read_element_idx( int row, int col, this_matrix const & x )
         {
-        BOOST_QVM_ASSERT(row==0);
+        BOOST_QVM_ASSERT(row==0); (void)row;
         BOOST_QVM_ASSERT(col>=0);
         BOOST_QVM_ASSERT(col<cols);
         return vec_traits<OriginalVector>::read_element_idx(col,reinterpret_cast<OriginalVector const &>(x));
@@ -491,7 +491,7 @@ qvm_detail
             {
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows-1);
-            BOOST_QVM_ASSERT(col==cols-1);
+            BOOST_QVM_ASSERT(col==cols-1); (void)col;
             return vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x));
             }
         };
@@ -528,7 +528,7 @@ qvm_detail
             {
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows);
-            BOOST_QVM_ASSERT(col==cols-1);
+            BOOST_QVM_ASSERT(col==cols-1); (void)col;
             BOOST_QVM_ASSERT(col!=row);
             vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x), s);
             }
@@ -679,7 +679,7 @@ qvm_detail
             {
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows);
-            BOOST_QVM_ASSERT(row==col);
+            BOOST_QVM_ASSERT(row==col); (void)col;
             return vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x));
             }
         };
@@ -712,7 +712,7 @@ qvm_detail
             {
             BOOST_QVM_ASSERT(row>=0);
             BOOST_QVM_ASSERT(row<rows);
-            BOOST_QVM_ASSERT(row==col);
+            BOOST_QVM_ASSERT(row==col); (void)col;
             vec_traits<OriginalVector>::write_element_idx(row,reinterpret_cast<OriginalVector &>(x), s);
             }
         };

--- a/include/boost/qvm/mat_operations.hpp
+++ b/include/boost/qvm/mat_operations.hpp
@@ -1109,9 +1109,9 @@ mat_traits< qvm_detail::zero_mat_<T,Rows,Cols> >
     scalar_type
     read_element_idx( int row, int col, this_matrix const & )
         {
-        BOOST_QVM_ASSERT(row>=0);
+        BOOST_QVM_ASSERT(row>=0); (void)row;
         BOOST_QVM_ASSERT(row<rows);
-        BOOST_QVM_ASSERT(col>=0);
+        BOOST_QVM_ASSERT(col>=0); (void)col;
         BOOST_QVM_ASSERT(col<cols);
         return scalar_traits<scalar_type>::value(0);
         }

--- a/include/boost/qvm/quat_operations.hpp
+++ b/include/boost/qvm/quat_operations.hpp
@@ -935,7 +935,7 @@ quat_traits< qvm_detail::zero_q_<T> >
     scalar_type
     read_element_idx( int i, this_quaternion const & )
         {
-        BOOST_QVM_ASSERT(i>=0);
+        BOOST_QVM_ASSERT(i>=0); (void)i;
         BOOST_QVM_ASSERT(i<4);
         return scalar_traits<scalar_type>::value(0);
         }

--- a/include/boost/qvm/vec_operations.hpp
+++ b/include/boost/qvm/vec_operations.hpp
@@ -221,7 +221,7 @@ vec_traits< qvm_detail::zero_vec_<T,Dim> >
     scalar_type
     read_element_idx( int i, this_vector const & )
         {
-        BOOST_QVM_ASSERT(i>=0);
+        BOOST_QVM_ASSERT(i>=0); (void)i;
         BOOST_QVM_ASSERT(i<Dim);
         return scalar_traits<scalar_type>::value(0);
         }


### PR DESCRIPTION
BOOST_QVM_ASSERT is disabled there, so cast the variables to void instead.

Otherwise a user of QVM with -Wextra (and clang, didn't happen with GCC for some reason) is spammed with lots of warnings in those headers.