### PR TITLE
Add constexpr to quat,mat and vec

### DIFF
--- a/include/boost/qvm/mat.hpp
+++ b/include/boost/qvm/mat.hpp
@@ -21,7 +21,7 @@ mat
         , class = typename enable_if<is_mat<R> >::type
 #endif
     >
-    operator R() const
+    BOOST_QVM_CONSTEXPR operator R() const
         {
         R r;
         assign(r,*this);

--- a/include/boost/qvm/quat.hpp
+++ b/include/boost/qvm/quat.hpp
@@ -21,7 +21,7 @@ quat
         , class = typename enable_if<is_quat<R> >::type
 #endif
     >
-    operator R() const
+    BOOST_QVM_CONSTEXPR operator R() const
         {
         R r;
         assign(r,*this);

--- a/include/boost/qvm/vec.hpp
+++ b/include/boost/qvm/vec.hpp
@@ -21,7 +21,7 @@ vec
         , class = typename enable_if<is_vec<R> >::type
 #endif
     >
-    operator R() const
+    BOOST_QVM_CONSTEXPR operator R() const
         {
         R r;
         assign(r,*this);


### PR DESCRIPTION
This is required for constexpr assignment which requires converting to a user defined type.